### PR TITLE
Fix Mangools API field mapping (AI metrics + SERPWatcher stats)

### DIFF
--- a/scripts/seo-report.js
+++ b/scripts/seo-report.js
@@ -72,17 +72,53 @@ async function fetchSerpwatcher(raw) {
     const detail = await api(`/serpwatcher/trackings/${trackingId}/detail`);
     raw.trackingDetail = detail;
 
-    const keywords = (detail?.tracked_keywords ?? detail?.keywords ?? []).map((kw) => ({
+    // Rank data lives in the stats endpoint; its exact contract is undocumented,
+    // so try the plausible variants and keep the raw dump for diagnosis.
+    const today = new Date();
+    const from = new Date(today.getTime() - 30 * 86400000);
+    const iso = (d) => d.toISOString().slice(0, 10);
+    const compact = (d) => iso(d).replaceAll('-', '');
+    const attempts = [
+        { label: 'GET compact', path: `/serpwatcher/trackings/${trackingId}/stats?from=${compact(from)}&to=${compact(today)}` },
+        { label: 'GET iso', path: `/serpwatcher/trackings/${trackingId}/stats?from=${iso(from)}&to=${iso(today)}` },
+        { label: 'POST iso', path: `/serpwatcher/trackings/${trackingId}/stats`, options: { method: 'POST', body: JSON.stringify({ from: iso(from), to: iso(today) }) } }
+    ];
+    let stats = null;
+    for (const attempt of attempts) {
+        try {
+            stats = await api(attempt.path, attempt.options ?? {});
+            raw.stats = stats;
+            raw.statsVariant = attempt.label;
+            break;
+        } catch (err) {
+            raw[`statsError (${attempt.label})`] = err.message;
+        }
+    }
+
+    const rankOf = (kw) => {
+        const direct = kw.rank?.value ?? (typeof kw.rank === 'number' ? kw.rank : null) ?? kw.position ?? null;
+        if (direct != null) return direct;
+        const history = kw.rank_history ?? kw.history ?? kw.ranks;
+        if (Array.isArray(history) && history.length) {
+            const last = history.at(-1);
+            return last?.rank ?? last?.value ?? (typeof last === 'number' ? last : null);
+        }
+        return null;
+    };
+
+    const source = stats?.tracked_keywords ?? stats?.keywords ?? stats?.stats?.keywords ?? detail?.keywords ?? [];
+    const keywords = source.map((kw) => ({
         keyword: kw.kw ?? kw.keyword ?? '',
-        rank: kw.rank?.value ?? kw.rank ?? null,
-        rankAvg: kw.rank_avg ?? null,
-        change: kw.rank_change ?? kw.change ?? null,
-        searchVolume: kw.search_volume ?? kw.sv ?? null
+        rank: rankOf(kw),
+        rankAvg: kw.rank_avg ?? kw.rankAvg ?? null,
+        change: kw.rank_change ?? kw.rankChange ?? kw.change ?? null,
+        searchVolume: kw.search_volume ?? kw.searchVolume ?? kw.sv ?? null
     }));
 
     return {
         trackingId,
-        performanceIndex: detail?.performance_index ?? detail?.pi ?? null,
+        performanceIndex:
+            stats?.performance_index ?? stats?.performanceIndex ?? stats?.stats?.performance_index ?? stats?.stats?.performanceIndex ?? null,
         keywords
     };
 }
@@ -94,19 +130,29 @@ async function fetchAiWatcher(raw) {
     const results = [];
     for (const monitor of list) {
         const id = monitor._id ?? monitor.id;
-        let detail = monitor;
+        let detail = null;
         try {
             detail = await api(`/aiwatcher/monitor/${id}`);
             raw[`aiMonitor_${id}`] = detail;
         } catch (err) {
             console.warn(`AI monitor ${id} detail failed: ${err.message}`);
         }
+
+        // metrics.*.value is null while the current period is still collecting;
+        // fall back to the newest completed timeSeries point.
+        const metrics = detail?.metrics ?? {};
+        const series = Array.isArray(detail?.timeSeries) ? detail.timeSeries : [];
+        const lastPoint = series.at(-1) ?? {};
+        const ownBrand = detail?.rankings?.brands?.find((b) => b.isMatch);
+
         results.push({
             id,
-            name: monitor.name ?? monitor.domain ?? String(id),
-            visibility: detail?.visibility ?? detail?.share_of_voice ?? detail?.stats?.visibility ?? null,
-            mentions: detail?.mentions ?? detail?.stats?.mentions ?? null,
-            promptCount: detail?.prompts_count ?? detail?.prompts?.length ?? null
+            name: monitor.brand ?? monitor.domain ?? String(id),
+            score: metrics.score?.value ?? lastPoint.score ?? null,
+            visibility: metrics.visibility?.value ?? lastPoint.visibility ?? null,
+            position: metrics.position?.value ?? lastPoint.position ?? null,
+            frequency: ownBrand?.frequency ?? null,
+            timeSeries: series.map((p) => ({ date: p.date, score: p.score ?? null, visibility: p.visibility ?? null, position: p.position ?? null }))
         });
     }
     return results;
@@ -135,9 +181,9 @@ function formatReport(snapshot) {
 
     if (snapshot.aiSearch?.length) {
         lines.push('## AI Search Watcher – Sichtbarkeit in KI-Antworten', '');
-        lines.push('| Monitor | Sichtbarkeit | Erwähnungen | Prompts |', '|---|---|---|---|');
+        lines.push('| Monitor | Sichtbarkeit % | Ø Position | Score | Zitierungen |', '|---|---|---|---|---|');
         for (const monitor of snapshot.aiSearch) {
-            lines.push(`| ${monitor.name} | ${monitor.visibility ?? '–'} | ${monitor.mentions ?? '–'} | ${monitor.promptCount ?? '–'} |`);
+            lines.push(`| ${monitor.name} | ${monitor.visibility ?? '–'} | ${monitor.position ?? '–'} | ${monitor.score ?? '–'} | ${monitor.frequency ?? '–'} |`);
         }
         lines.push('');
     }

--- a/src/pages/seo-dashboard.astro
+++ b/src/pages/seo-dashboard.astro
@@ -5,9 +5,10 @@ import reviews from '../data/google-reviews.json';
 
 // Private dashboard: noindex + excluded from sitemap (astro.config.mjs filter)
 
+type AiPoint = { date: string; score: number | null; visibility: number | null; position: number | null };
 type Snapshot = (typeof metrics.snapshots)[number] & {
     serpwatcher?: { performanceIndex: number | null; keywords: { keyword: string; rank: number | null; change: number | null; searchVolume: number | null }[] } | null;
-    aiSearch?: { name: string; visibility: number | null; mentions: number | null; promptCount: number | null }[] | null;
+    aiSearch?: { name: string; score: number | null; visibility: number | null; position: number | null; frequency: number | null; timeSeries?: AiPoint[] }[] | null;
 };
 
 const snapshots = metrics.snapshots as Snapshot[];
@@ -29,6 +30,15 @@ for (const snap of snapshots) {
 
 /** Inline SVG sparkline: lower rank = better = drawn higher. */
 function sparkline(series: (number | null)[], width = 120, height = 28): string {
+    return sparklineRaw(series, width, height, true);
+}
+
+/** Sparkline where higher value = better = drawn higher (visibility, score). */
+function sparklineUp(series: (number | null)[], width = 120, height = 28): string {
+    return sparklineRaw(series, width, height, false);
+}
+
+function sparklineRaw(series: (number | null)[], width: number, height: number, invert: boolean): string {
     const values = series.filter((v): v is number => v != null);
     if (values.length < 2) return '';
     const min = Math.min(...values);
@@ -36,7 +46,12 @@ function sparkline(series: (number | null)[], width = 120, height = 28): string 
     const range = max - min || 1;
     const step = width / (series.length - 1);
     const points = series
-        .map((v, i) => (v == null ? null : `${(i * step).toFixed(1)},${(2 + ((v - min) / range) * (height - 4)).toFixed(1)}`))
+        .map((v, i) => {
+            if (v == null) return null;
+            const norm = (v - min) / range;
+            const y = invert ? 2 + norm * (height - 4) : 2 + (1 - norm) * (height - 4);
+            return `${(i * step).toFixed(1)},${y.toFixed(1)}`;
+        })
         .filter(Boolean)
         .join(' ');
     return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" aria-hidden="true"><polyline fill="none" stroke="#dc2626" stroke-width="2" points="${points}" /></svg>`;
@@ -73,8 +88,9 @@ const perfSeries = snapshots.map((snap) => snap.serpwatcher?.performanceIndex ??
         {latest?.aiSearch?.[0] && (
             <div class="rounded-xl border border-gray-300 p-5">
                 <div class="text-sm opacity-70">KI-Sichtbarkeit ({latest.aiSearch[0].name})</div>
-                <div class="text-3xl font-black">{latest.aiSearch[0].visibility ?? '–'}</div>
-                <div class="text-sm opacity-70">{latest.aiSearch[0].mentions ?? '–'} Erwähnungen</div>
+                <div class="text-3xl font-black">{latest.aiSearch[0].visibility != null ? `${Math.round(latest.aiSearch[0].visibility)}%` : '–'}</div>
+                <div class="text-sm opacity-70">Ø Position {latest.aiSearch[0].position ?? '–'} in KI-Antworten</div>
+                <div set:html={sparklineUp((latest.aiSearch[0].timeSeries ?? []).map((p) => p.visibility))} />
             </div>
         )}
     </div>
@@ -120,17 +136,19 @@ const perfSeries = snapshots.map((snap) => snap.serpwatcher?.performanceIndex ??
                         <tr class="text-left border-b border-gray-400">
                             <th class="py-2 pr-4">Monitor</th>
                             <th class="py-2 pr-4">Sichtbarkeit</th>
-                            <th class="py-2 pr-4">Erwähnungen</th>
-                            <th class="py-2">Prompts</th>
+                            <th class="py-2 pr-4">Ø Position</th>
+                            <th class="py-2 pr-4">Score</th>
+                            <th class="py-2">Verlauf (Sichtbarkeit)</th>
                         </tr>
                     </thead>
                     <tbody>
                         {latest.aiSearch.map((monitor) => (
                             <tr class="border-b border-gray-200">
                                 <td class="py-2 pr-4 font-bold">{monitor.name}</td>
-                                <td class="py-2 pr-4">{monitor.visibility ?? '–'}</td>
-                                <td class="py-2 pr-4">{monitor.mentions ?? '–'}</td>
-                                <td class="py-2">{monitor.promptCount ?? '–'}</td>
+                                <td class="py-2 pr-4">{monitor.visibility != null ? `${Math.round(monitor.visibility)}%` : '–'}</td>
+                                <td class="py-2 pr-4">{monitor.position ?? '–'}</td>
+                                <td class="py-2 pr-4">{monitor.score != null ? Math.round(monitor.score) : '–'}</td>
+                                <td class="py-2" set:html={sparklineUp((monitor.timeSeries ?? []).map((p) => p.visibility))} />
                             </tr>
                         ))}
                     </tbody>


### PR DESCRIPTION
First Action run produced all-null metrics: `/detail` has no rank data and the AI metrics live in `metrics`/`timeSeries`, not top-level fields. Verified against the committed `raw-last.json`: your AI visibility is actually 55–65% at Ø position ~4 — the data was there all along.

- AI Search Watcher mapping fixed (metrics.*.value → timeSeries fallback), dashboard shows visibility % + position + sparkline
- SERPWatcher now calls the stats endpoint (3 request variants, raw-dumped for diagnosis)
- Dashboard render verified locally with real-shaped data

After merge: re-run **Actions → Weekly SEO report** — it overwrites the W30 snapshot in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)