### PR TITLE
Fix SERPWatcher stats mapping + real W30 data

### DIFF
--- a/reports/seo/2026-W30.md
+++ b/reports/seo/2026-W30.md
@@ -4,14 +4,16 @@ Domain: bern-hypnose.ch
 
 ## SERPWatcher – Rankings
 
-| Keyword | Position | Δ | Suchvolumen |
-|---|---|---|---|
-|  | 1 | = | 660 |
-|  | 4 | ▼ 1 | 170 |
-|  | 1 | = | 660 |
-|  | 4 | = | 170 |
-|  | 4 | ▼ 1 | – |
-|  | 2 | = | 170 |
+Performance-Index: **86.6** · geschätzte Besuche/Monat: **437**
+
+| Keyword | Position | Δ | Ø | Suchvolumen | Besuche (geschätzt) |
+|---|---|---|---|---|---|
+| hypnose bern | 1 | = | 1.2 | 660 | 196 |
+| hypnosetherapie bern | 3 | ▼ 1 | 3.8 | 170 | 11 |
+| bern hypnose | 1 | = | 1 | 660 | 196 |
+| hypnosetherapeut bern | 4 | = | 5.4 | 170 | 7 |
+| hypnosetherapeutin bern | 3 | ▼ 1 | 3.4 | – | – |
+| hypnose therapie bern | 2 | = | 2 | 170 | 27 |
 
 ## AI Search Watcher – Sichtbarkeit in KI-Antworten
 

--- a/reports/seo/raw-last.json
+++ b/reports/seo/raw-last.json
@@ -995,8 +995,6 @@
       }
     ]
   },
-  "statsError (GET compact)": "Mangools API 404 on /serpwatcher/trackings/69159128598016b4d9930e1a/stats?from=20260623&to=20260723: {\"error\":{\"type\":\"Error\",\"message\":\"Not Found\"}}",
-  "statsError (GET iso)": "Mangools API 404 on /serpwatcher/trackings/69159128598016b4d9930e1a/stats?from=2026-06-23&to=2026-07-23: {\"error\":{\"type\":\"Error\",\"message\":\"Not Found\"}}",
   "stats": {
     "history_dates": [
       "2026-07-13",

--- a/scripts/seo-report.js
+++ b/scripts/seo-report.js
@@ -79,9 +79,9 @@ async function fetchSerpwatcher(raw) {
     const iso = (d) => d.toISOString().slice(0, 10);
     const compact = (d) => iso(d).replaceAll('-', '');
     const attempts = [
+        { label: 'POST iso', path: `/serpwatcher/trackings/${trackingId}/stats`, options: { method: 'POST', body: JSON.stringify({ from: iso(from), to: iso(today) }) } },
         { label: 'GET compact', path: `/serpwatcher/trackings/${trackingId}/stats?from=${compact(from)}&to=${compact(today)}` },
-        { label: 'GET iso', path: `/serpwatcher/trackings/${trackingId}/stats?from=${iso(from)}&to=${iso(today)}` },
-        { label: 'POST iso', path: `/serpwatcher/trackings/${trackingId}/stats`, options: { method: 'POST', body: JSON.stringify({ from: iso(from), to: iso(today) }) } }
+        { label: 'GET iso', path: `/serpwatcher/trackings/${trackingId}/stats?from=${iso(from)}&to=${iso(today)}` }
     ];
     let stats = null;
     for (const attempt of attempts) {
@@ -95,30 +95,31 @@ async function fetchSerpwatcher(raw) {
         }
     }
 
-    const rankOf = (kw) => {
-        const direct = kw.rank?.value ?? (typeof kw.rank === 'number' ? kw.rank : null) ?? kw.position ?? null;
-        if (direct != null) return direct;
-        const history = kw.rank_history ?? kw.history ?? kw.ranks;
-        if (Array.isArray(history) && history.length) {
-            const last = history.at(-1);
-            return last?.rank ?? last?.value ?? (typeof last === 'number' ? last : null);
-        }
-        return null;
-    };
+    // Stats keywords carry ranks but no names — join with /detail via _id.
+    const nameById = new Map((detail?.keywords ?? []).map((kw) => [kw._id, kw.kw]));
 
-    const source = stats?.tracked_keywords ?? stats?.keywords ?? stats?.stats?.keywords ?? detail?.keywords ?? [];
+    const source = stats?.keywords ?? [];
     const keywords = source.map((kw) => ({
-        keyword: kw.kw ?? kw.keyword ?? '',
-        rank: rankOf(kw),
-        rankAvg: kw.rank_avg ?? kw.rankAvg ?? null,
-        change: kw.rank_change ?? kw.rankChange ?? kw.change ?? null,
-        searchVolume: kw.search_volume ?? kw.searchVolume ?? kw.sv ?? null
+        keyword: nameById.get(kw._id) ?? kw.kw ?? '',
+        rank: kw.rank?.last ?? null,
+        rankAvg: kw.rank?.avg ?? null,
+        rankBest: kw.rank?.best ?? null,
+        change: kw.rank_change ?? null,
+        searchVolume: kw.search_volume ?? null,
+        estimatedVisits: kw.estimated_visits ?? null,
+        mapPackRank: kw.map_pack?.rank != null && kw.map_pack.rank > 0 ? kw.map_pack.rank : null
     }));
+
+    // timeframes is keyed by date — take the most recent entry
+    const timeframes = stats?.stats?.timeframes ?? {};
+    const lastDate = Object.keys(timeframes).sort().at(-1);
+    const lastFrame = lastDate ? timeframes[lastDate] : null;
 
     return {
         trackingId,
-        performanceIndex:
-            stats?.performance_index ?? stats?.performanceIndex ?? stats?.stats?.performance_index ?? stats?.stats?.performanceIndex ?? null,
+        performanceIndex: lastFrame?.performance_index != null ? Math.round(lastFrame.performance_index * 10) / 10 : null,
+        visibilityIndex: lastFrame?.visibility_index != null ? Math.round(lastFrame.visibility_index * 100) / 100 : null,
+        estimatedVisits: lastFrame?.estimated_visits ?? null,
         keywords
     };
 }
@@ -169,12 +170,15 @@ function formatReport(snapshot) {
     if (snapshot.serpwatcher) {
         lines.push('## SERPWatcher – Rankings', '');
         if (snapshot.serpwatcher.performanceIndex != null) {
-            lines.push(`Performance-Index: **${snapshot.serpwatcher.performanceIndex}**`, '');
+            lines.push(
+                `Performance-Index: **${snapshot.serpwatcher.performanceIndex}** · geschätzte Besuche/Monat: **${snapshot.serpwatcher.estimatedVisits ?? '–'}**`,
+                ''
+            );
         }
-        lines.push('| Keyword | Position | Δ | Suchvolumen |', '|---|---|---|---|');
+        lines.push('| Keyword | Position | Δ | Ø | Suchvolumen | Besuche (geschätzt) |', '|---|---|---|---|---|---|');
         for (const kw of snapshot.serpwatcher.keywords) {
             const delta = kw.change == null ? '–' : kw.change > 0 ? `▲ ${kw.change}` : kw.change < 0 ? `▼ ${Math.abs(kw.change)}` : '=';
-            lines.push(`| ${kw.keyword} | ${kw.rank ?? '–'} | ${delta} | ${kw.searchVolume ?? '–'} |`);
+            lines.push(`| ${kw.keyword} | ${kw.rank ?? '–'} | ${delta} | ${kw.rankAvg ?? '–'} | ${kw.searchVolume ?? '–'} | ${kw.estimatedVisits ?? '–'} |`);
         }
         lines.push('');
     }

--- a/src/data/seo-metrics.json
+++ b/src/data/seo-metrics.json
@@ -5,49 +5,69 @@
       "week": "2026-W30",
       "serpwatcher": {
         "trackingId": "69159128598016b4d9930e1a",
-        "performanceIndex": null,
+        "performanceIndex": 86.6,
+        "visibilityIndex": 13.42,
+        "estimatedVisits": 437,
         "keywords": [
           {
-            "keyword": "",
+            "keyword": "hypnose bern",
             "rank": 1,
-            "rankAvg": null,
+            "rankAvg": 1.2,
+            "rankBest": 1,
             "change": 0,
-            "searchVolume": 660
+            "searchVolume": 660,
+            "estimatedVisits": 196,
+            "mapPackRank": null
           },
           {
-            "keyword": "",
-            "rank": 4,
-            "rankAvg": null,
+            "keyword": "hypnosetherapie bern",
+            "rank": 3,
+            "rankAvg": 3.8,
+            "rankBest": 3,
             "change": -1,
-            "searchVolume": 170
+            "searchVolume": 170,
+            "estimatedVisits": 11,
+            "mapPackRank": null
           },
           {
-            "keyword": "",
+            "keyword": "bern hypnose",
             "rank": 1,
-            "rankAvg": null,
+            "rankAvg": 1,
+            "rankBest": 1,
             "change": 0,
-            "searchVolume": 660
+            "searchVolume": 660,
+            "estimatedVisits": 196,
+            "mapPackRank": null
           },
           {
-            "keyword": "",
+            "keyword": "hypnosetherapeut bern",
             "rank": 4,
-            "rankAvg": null,
+            "rankAvg": 5.4,
+            "rankBest": 4,
             "change": 0,
-            "searchVolume": 170
+            "searchVolume": 170,
+            "estimatedVisits": 7,
+            "mapPackRank": null
           },
           {
-            "keyword": "",
-            "rank": 4,
-            "rankAvg": null,
+            "keyword": "hypnosetherapeutin bern",
+            "rank": 3,
+            "rankAvg": 3.4,
+            "rankBest": 3,
             "change": -1,
-            "searchVolume": null
+            "searchVolume": null,
+            "estimatedVisits": null,
+            "mapPackRank": null
           },
           {
-            "keyword": "",
+            "keyword": "hypnose therapie bern",
             "rank": 2,
-            "rankAvg": null,
+            "rankAvg": 2,
+            "rankBest": 2,
             "change": 0,
-            "searchVolume": 170
+            "searchVolume": 170,
+            "estimatedVisits": 27,
+            "mapPackRank": null
           }
         ]
       },


### PR DESCRIPTION
Tested against the live Mangools API (key from local .env). The working contract: POST /stats with ISO dates; keyword names joined from /detail by _id; performance index from stats.timeframes.

W30 snapshot + report regenerated with real data — merging fills /seo-dashboard/ on the next deploy, no Action run needed. Verified locally: dashboard renders PI 86.6, keyword table with ranks, AI visibility card 56% + sparkline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)